### PR TITLE
Bugfix: Character appearance backup incompatibility

### DIFF
--- a/Curse/Room/WardrobeV2.js
+++ b/Curse/Room/WardrobeV2.js
@@ -53,7 +53,7 @@ function LoadAppearanceV2() {
   
     AppearanceBuildAssets(C);
     AppearanceMode = "";
-    CharacterAppearanceBackup = C.Appearance.map(Item => Object.assign({}, Item));
+    CharacterAppearanceBackup = CharacterAppearanceStringify(C);
   };
   
   // Run the character appearance selection screen


### PR DESCRIPTION
The character appearance backup was recently changed to a serialised string to ensure the appearance cancel button always worked correctly (`CharacterAppearanceStringify` is a new function).