### PR TITLE
Created separate messages for Whisper vs OOC

### DIFF
--- a/Curse/Checks/SelfMessageCheck.js
+++ b/Curse/Checks/SelfMessageCheck.js
@@ -27,8 +27,8 @@ function SelfMessageCheck(msg) {
     cursedConfig.hasBlockedWhisper && cursedConfig.hasIntenseVersion
     && !Player.CanTalk() && isWhisper
   ) {
-    NotifyOwners({ Tag: "SelfMsgCheckNotifyGagOOC" });
-    popChatSilent({ Tag: "SelfMsgCheckWearerWarnGagOOC" });
+    NotifyOwners({ Tag: "SelfMsgCheckNotifyGagWhisper" });
+    popChatSilent({ Tag: "SelfMsgCheckWearerWarnGagWhisper" });
     TriggerPunishment(27);
     r = true;
   }

--- a/Curse/Dictionary/EN.js
+++ b/Curse/Dictionary/EN.js
@@ -141,6 +141,8 @@ var cursedEN = {
   "WearerShowSentences": "Here are your allowed sentences --> {0}",
   "SelfMsgCheckNotifyGagOOC": "(Tried to use OOC while gagged)",
   "SelfMsgCheckWearerWarnGagOOC": "WARNING: You are not allowed to use OOC in normal chat messages while gagged.",
+  "SelfMsgCheckNotifyGagWhisper": "(Tried to whisper while gagged)",
+  "SelfMsgCheckWearerWarnGagWhisper": "WARNING: You are not allowed to whisper while gagged.",
   "SelfMsgCheckCommandCallError": "(A command call was detected, but unidentified. Check for typos and verify your version if this was intended. This message will be processed normally.)",
   "SelfMsgCheckNotifyForceSay": "(Did not say the sentence willingly.)",
   "SelfMsgCheckWarnForceSay": "WARNING: You were punished for not saying the expected sentence willingly: {0}",


### PR DESCRIPTION
Always thought it was confusing that blocked whispers returned a blocked OOC message.  Added necessary text strings for EN.js dictionary and updated in SelfMessageCheck.js; someone with more language knowledge will need to add the appropriate translations to FR, GER and RU dictionaries.